### PR TITLE
fix: Use fqdn versus relative pathing to binaries.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -366,15 +366,17 @@ while true; do
             fi
 
             # it is important to use tabs over spaces for indenting here. otherwise, <<- doesn't work.
+            #
+            # we use the full path to the files versus changing directories as it was observed that users using a custom
+            # path when mounting/installing on an SD card cannot use cd in the command prompt when navigating to C:\.
             cat <<-EOF > "${HOME}/.steam/steam/steamapps/compatdata/${wine_prefix}/pfx/drive_c/users/steamuser/run.bat"
 				@echo off
-				cd "C:\users\steamuser\dqxclarity"
-				if not exist venv (
+				if not exist C:\users\steamuser\dqxclarity\venv (
 					echo Installing requirements. This may take a minute.
-					python -m venv venv
-					.\venv\Scripts\python.exe -m pip install -r requirements.txt
+					C:\users\steamuser\dqxclarity\python -m venv C:\users\steamuser\dqxclarity\venv
+					C:\users\steamuser\dqxclarity\venv\Scripts\python.exe -m pip install -r C:\users\steamuser\dqxclarity\requirements.txt
 				)
-				start "" .\venv\Scripts\python.exe main.py ${concat_choices}
+				start "" C:\users\steamuser\dqxclarity\venv\Scripts\python.exe C:\users\steamuser\dqxclarity\main.py ${concat_choices}
 				start "" "C:\Program Files (x86)\SquareEnix\DRAGON QUEST X\Boot\DQXBoot.exe"
 			EOF
 


### PR DESCRIPTION
Had a user that installed their wine prefix on an SD card. When they opened the command prompt, it defaulted them to a Z:\ drive. They could not `cd` to C:\, `cd` wasn't working in the bat script and they could not launch dqxclarity. Using full paths had fixed it for them. This behavior is OK as the default.